### PR TITLE
Generic fallback for each (supports dense arrays)

### DIFF
--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1,0 +1,34 @@
+A = [1 5 -5;
+     0 3 2]
+
+@test each(index(A)) == CartesianRange((1:2, 1:3))
+@test each(index(A, :, 1:2)) == CartesianRange((1:2, 1:2))
+@test each(index(A, :, 2:3)) == CartesianRange((1:2, 2:3))
+
+k = 0
+for j in inds(A, 2)
+    for v in each(A, :, j)
+        @test v == A[k+=1]
+    end
+end
+
+k = 0
+for j in inds(A, 2)
+    for I in each(index(A, :, j))
+        @test A[I] == A[k+=1]
+    end
+end
+
+k = 0
+for j in inds(A, 2)
+    for I in eachindex(stored(A, :, j))
+        @test A[I] == A[k+=1]
+    end
+end
+
+k = 0
+for j in inds(A, 2)
+    for v in each(stored(A, :, j))
+        @test v == A[k+=1]
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,11 @@
 using ArrayIterationPlayground
 using Base.Test
 
+A = zeros(2,3)
+@test inds(A, 1) == 1:2
+@test inds(A, 2) == 1:3
+@test inds(A, 3) == 1:1
+@test inds(A) == (1:2, 1:3)
+
+include("dense.jl")
 include("sparse.jl")

--- a/test/sparse.jl
+++ b/test/sparse.jl
@@ -2,28 +2,28 @@ A = sparse([1,4,3],[1,1,2],[0.2,0.4,0.6])
 Af = full(A)
 
 k = 0
-for j = 1:2
-    for i in eachindex(stored(A, :, j))
-        @test A[i,j] == A.nzval[k+=1]
+for j = inds(A, 2)
+    for I in eachindex(stored(A, :, j))
+        @test A[I] == A.nzval[k+=1]
     end
 end
 
 k = 0
-for j = 1:2
+for j = inds(A, 2)
     for v in each(stored(A, :, j))
         @test v == A.nzval[k+=1]
     end
 end
 
 k = 0
-for j = 1:2
-    for i in each(index(A, :, j))
-        @test A[i,j] == Af[k+=1]
+for j = inds(A, 2)
+    for I in each(index(A, :, j))
+        @test A[I] == Af[k+=1]
     end
 end
 
 k = 0
-for j = 1:2
+for j = inds(A, 2)
     for v in each(A, :, j)
         @test v == Af[k+=1]
     end


### PR DESCRIPTION
This changes the API so that the inner "each" loop returns a complete iterator, rather than just a dimensional iterator. This seems a little more self-consistent, but it could present generalization problems later. We'll have to see how it works out.
